### PR TITLE
fix(FOM-66): stop the apply being skipped as a duplicate of its own plan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,10 @@ jobs:
         with:
           cancel_others: 'true'
           concurrent_skipping: 'same_content_newer'
+          # A squash merge has the same tree as the PR that just planned it, so
+          # dedup treats the apply as a duplicate and skips it. Content can't
+          # tell a plan from an apply.
+          do_not_skip: '["push", "workflow_dispatch", "schedule", "merge_group"]'
 
   Org:
     name: ${{ github.event_name == 'pull_request' && 'Plan Org' || 'Apply Org' }}


### PR DESCRIPTION
Merging #35 skipped every apply job. Pre-check found the PR's own plan run had already checked the identical tree and called the merge a duplicate, so `should_skip` came back true and org, dev and prod all skipped. Nothing was applied. [FOM-66](https://linear.app/fomiller/issue/FOM-66/set-up-aws-identity-center-and-sso)

Adds `push` to `do_not_skip`. A squash merge always has the same tree as the PR that planned it, and content can't distinguish a plan from an apply, so pushes to main must never dedup. PR-to-PR dedup is unchanged.

Merging this re-triggers the apply that #35 should have run.