### PR TITLE
feat(FOM-130): let member github-actions roles assume the org role

### DIFF
--- a/infra/modules/aws/org/github-oidc/_data.tf
+++ b/infra/modules/aws/org/github-oidc/_data.tf
@@ -37,4 +37,28 @@ data "aws_iam_policy_document" "github_actions" {
       ]
     }
   }
+
+  # Some member-account stacks manage resources that live here — the
+  # aws-infra-shared-services route53 unit owns hosted zones in this account
+  # from a job running in dev. Those jobs chain into this role instead of
+  # carrying a static key for it.
+  #
+  # The account principal covers a human on SSO doing the same thing locally.
+  # It grants nothing on its own: the caller still needs sts:AssumeRole.
+  dynamic "statement" {
+    for_each = length(var.assuming_account_ids) > 0 ? [1] : []
+
+    content {
+      effect  = "Allow"
+      actions = ["sts:AssumeRole"]
+
+      principals {
+        type = "AWS"
+        identifiers = concat(
+          [for id in var.assuming_account_ids : "arn:aws:iam::${id}:role/github-actions"],
+          ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"],
+        )
+      }
+    }
+  }
 }

--- a/infra/modules/aws/org/github-oidc/_data.tf
+++ b/infra/modules/aws/org/github-oidc/_data.tf
@@ -43,8 +43,8 @@ data "aws_iam_policy_document" "github_actions" {
   # from a job running in dev. Those jobs chain into this role instead of
   # carrying a static key for it.
   #
-  # The account principal covers a human on SSO doing the same thing locally.
-  # It grants nothing on its own: the caller still needs sts:AssumeRole.
+  # The account principal covers anyone already in this account. It grants
+  # nothing on its own: the caller still needs sts:AssumeRole.
   dynamic "statement" {
     for_each = length(var.assuming_account_ids) > 0 ? [1] : []
 
@@ -58,6 +58,35 @@ data "aws_iam_policy_document" "github_actions" {
           [for id in var.assuming_account_ids : "arn:aws:iam::${id}:role/github-actions"],
           ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"],
         )
+      }
+    }
+  }
+
+  # Same chain, but for a person. Running the same stack locally means a member
+  # account profile for the default provider, so the Identity Center role has to
+  # reach this one too. Identity Center names roles with a random suffix, so the
+  # match is on the path it puts them under rather than a fixed ARN.
+  dynamic "statement" {
+    for_each = length(var.assuming_account_ids) > 0 ? [1] : []
+
+    content {
+      effect  = "Allow"
+      actions = ["sts:AssumeRole"]
+
+      principals {
+        type        = "AWS"
+        identifiers = [for id in var.assuming_account_ids : "arn:aws:iam::${id}:root"]
+      }
+
+      condition {
+        test     = "ArnLike"
+        variable = "aws:PrincipalArn"
+        values = flatten([
+          for id in var.assuming_account_ids : [
+            for ps in var.sso_permission_sets :
+            "arn:aws:sts::${id}:assumed-role/AWSReservedSSO_${ps}_*/*"
+          ]
+        ])
       }
     }
   }

--- a/infra/modules/aws/org/github-oidc/_variables.tf
+++ b/infra/modules/aws/org/github-oidc/_variables.tf
@@ -1,0 +1,7 @@
+# Member accounts whose github-actions role may assume this account's, for
+# stacks that run in a member account but manage resources here. Set in
+# env-config.
+variable "assuming_account_ids" {
+  type    = list(string)
+  default = []
+}

--- a/infra/modules/aws/org/github-oidc/_variables.tf
+++ b/infra/modules/aws/org/github-oidc/_variables.tf
@@ -5,3 +5,10 @@ variable "assuming_account_ids" {
   type    = list(string)
   default = []
 }
+
+# Identity Center permission set names allowed to make the same jump from those
+# accounts, so the stacks can be run by hand.
+variable "sso_permission_sets" {
+  type    = list(string)
+  default = []
+}

--- a/infra/modules/aws/org/github-oidc/env-config/us-east-1/org.tfvars
+++ b/infra/modules/aws/org/github-oidc/env-config/us-east-1/org.tfvars
@@ -1,1 +1,8 @@
 environment = "org"
+
+# dev and prod. aws-infra-shared-services runs in dev and manages route53
+# hosted zones that live in this account.
+assuming_account_ids = [
+  "695434033664",
+  "737133467188",
+]

--- a/infra/modules/aws/org/github-oidc/env-config/us-east-1/org.tfvars
+++ b/infra/modules/aws/org/github-oidc/env-config/us-east-1/org.tfvars
@@ -6,3 +6,8 @@ assuming_account_ids = [
   "695434033664",
   "737133467188",
 ]
+
+sso_permission_sets = [
+  "AdministratorAccess",
+  "CloudAdmin",
+]


### PR DESCRIPTION
aws-infra-shared-services runs in dev, but its route53 unit manages hosted zones that live in the org account. It does that with a second provider built from a static key for the `AWSTerraformORG` IAM user, pulled from Doppler. Deleting that user is the last step of [FOM-130](https://linear.app/fomiller/issue/FOM-130/move-ci-to-github-oidc-federated-roles), and doing it today breaks that unit.

Adds two `sts:AssumeRole` statements to the org `github-actions` role trust policy.

**CI.** The dev and prod `github-actions` roles can chain into it with the session they already got from OIDC. Plus the org account principal, for anything already in that account.

**Local.** Running the same stack by hand means an Identity Center profile for a member account — that's what the default provider needs — so that role has to reach the org role too. Identity Center appends a random suffix to role names, so this matches `ArnLike` on `aws:PrincipalArn` against the path it puts them under:

```
arn:aws:sts::<member>:assumed-role/AWSReservedSSO_AdministratorAccess_*/*
arn:aws:sts::<member>:assumed-role/AWSReservedSSO_CloudAdmin_*/*
```

Scoped to those two permission sets. `Developer` and `ReadOnlyAccess` don't get it. The `:root` principals grant nothing on their own — the caller still needs `sts:AssumeRole` in its own policy.

Plan is `0 to add, 1 to change, 0 to destroy`, trust policy only.

Merge this before the shared-services PR that drops the static key, or that repo's route53 unit fails.