### PR TITLE
refactor(FOM-130): drop the SSO chain from the org role trust

### DIFF
--- a/infra/modules/aws/org/github-oidc/_data.tf
+++ b/infra/modules/aws/org/github-oidc/_data.tf
@@ -61,33 +61,4 @@ data "aws_iam_policy_document" "github_actions" {
       }
     }
   }
-
-  # Same chain, but for a person. Running the same stack locally means a member
-  # account profile for the default provider, so the Identity Center role has to
-  # reach this one too. Identity Center names roles with a random suffix, so the
-  # match is on the path it puts them under rather than a fixed ARN.
-  dynamic "statement" {
-    for_each = length(var.assuming_account_ids) > 0 ? [1] : []
-
-    content {
-      effect  = "Allow"
-      actions = ["sts:AssumeRole"]
-
-      principals {
-        type        = "AWS"
-        identifiers = [for id in var.assuming_account_ids : "arn:aws:iam::${id}:root"]
-      }
-
-      condition {
-        test     = "ArnLike"
-        variable = "aws:PrincipalArn"
-        values = flatten([
-          for id in var.assuming_account_ids : [
-            for ps in var.sso_permission_sets :
-            "arn:aws:sts::${id}:assumed-role/AWSReservedSSO_${ps}_*/*"
-          ]
-        ])
-      }
-    }
-  }
 }

--- a/infra/modules/aws/org/github-oidc/_variables.tf
+++ b/infra/modules/aws/org/github-oidc/_variables.tf
@@ -5,10 +5,3 @@ variable "assuming_account_ids" {
   type    = list(string)
   default = []
 }
-
-# Identity Center permission set names allowed to make the same jump from those
-# accounts, so the stacks can be run by hand.
-variable "sso_permission_sets" {
-  type    = list(string)
-  default = []
-}

--- a/infra/modules/aws/org/github-oidc/env-config/us-east-1/org.tfvars
+++ b/infra/modules/aws/org/github-oidc/env-config/us-east-1/org.tfvars
@@ -6,8 +6,3 @@ assuming_account_ids = [
   "695434033664",
   "737133467188",
 ]
-
-sso_permission_sets = [
-  "AdministratorAccess",
-  "CloudAdmin",
-]


### PR DESCRIPTION
Removes the trust statement that let Identity Center roles in dev and prod assume the org account `github-actions` role, plus the `sso_permission_sets` variable that fed it.

Nothing needs that jump. `AdministratorAccess` is already assigned to the org account directly, so running the org-account stacks by hand is a matter of picking the org SSO profile. The CI statement stays — a dev job still chains into this role for the route53 hosted zones.